### PR TITLE
Delete article on staff data sharing with AI chatbots

### DIFF
--- a/news.json
+++ b/news.json
@@ -120,21 +120,6 @@
     "tags": ["data-leakage", "security", "governance"]
   },
   {
-    "slug": "businesses-struggle-staff-sharing-sensitive-data-ai-chatbots",
-    "title": "Businesses struggle to stop staff sharing sensitive data with AI chatbots",
-    "publishedAt": "2026-04-03",
-    "source": "Financial Times",
-    "language": "en",
-    "originalUrl": "https://www.ft.com/content/ai-chatbots-data-risk-summary",
-    "quote": "Companies are finding it difficult to prevent employees from sharing sensitive data with AI chat tools despite policies and controls.",
-    "summary": "Despite implementing policies and technical controls, organizations continue to struggle with preventing employees from sharing sensitive and confidential business data with AI chatbots. Research suggests that governance frameworks alone are insufficient to address the behavioral patterns driving this risk. Companies must supplement policy-based approaches with additional monitoring and enforcement mechanisms to effectively mitigate data leakage through AI chat interfaces.",
-    "relevanceBullets": [
-      "Laat zien dat medewerkers ondanks beleid gevoelige bedrijfsinformatie blijven invoeren in AI-chattools.",
-      "Benadrukt dat governance alleen niet voldoende is en dat aanvullende controlemechanismen nodig zijn om datalekken te voorkomen."
-    ],
-    "tags": ["data-leakage", "governance", "compliance"]
-  },
-  {
     "slug": "hidden-security-risks-shadow-ai-enterprises",
     "title": "The Hidden Security Risks of Shadow AI in Enterprises",
     "publishedAt": "2026-04-09",


### PR DESCRIPTION
Removed an article about businesses struggling to prevent staff from sharing sensitive data with AI chatbots.